### PR TITLE
Only contagious facilities

### DIFF
--- a/src/main/java/org/matsim/episim/EpisimConfigGroup.java
+++ b/src/main/java/org/matsim/episim/EpisimConfigGroup.java
@@ -161,8 +161,8 @@ public final class EpisimConfigGroup extends ReflectiveConfigGroup {
 	private int daysInfectious = 4;
 	private DistrictLevelRestrictions districtLevelRestrictions = DistrictLevelRestrictions.no;
 	private String districtLevelRestrictionsAttribute = "";
-	private ContagiousOptimization contagiousContainerOptimization = ContagiousOptimization.disable;
-	private ReportTimeUse reportTimeUse = ReportTimeUse.enable;
+	private ContagiousOptimization contagiousContainerOptimization = ContagiousOptimization.no;
+	private ReportTimeUse reportTimeUse = ReportTimeUse.yes;
 	private int threads = 2;
 	/**
 	 * Child susceptibility used in AgeDependentInfectionModelWithSeasonality.
@@ -1003,8 +1003,8 @@ public final class EpisimConfigGroup extends ReflectiveConfigGroup {
      * methods are only called, if a contagious person is in the container
      */	
 	public enum ContagiousOptimization {
-		enable,
-		disable
+		yes,
+		no
 	}
 	
 	/**
@@ -1012,8 +1012,8 @@ public final class EpisimConfigGroup extends ReflectiveConfigGroup {
      * can be disabled with
      */
 	public enum ReportTimeUse {
-		enable,
-		disable
+		yes,
+		no
 	}
 
 

--- a/src/main/java/org/matsim/episim/EpisimConfigGroup.java
+++ b/src/main/java/org/matsim/episim/EpisimConfigGroup.java
@@ -79,6 +79,8 @@ public final class EpisimConfigGroup extends ReflectiveConfigGroup {
 	private static final String CURFEW_COMPLIANCE = "curfewCompliance";
 	private static final String DISTRICT_LEVEL_RESTRICTIONS = "districtLevelRestrictions";
 	private static final String DISTRICT_LEVEL_RESTRICTIONS_ATTRIBUTE = "districtLevelRestrictionsAttribute";
+	private static final String CONTAGIOUS_CONTAINER_OPTIMIZATION = "contagiousContainerOptimization";
+	private static final String REPORT_TIME_USE = "reportTimeUse";
 
 	private static final Logger log = LogManager.getLogger(EpisimConfigGroup.class);
 	private static final String GROUPNAME = "episim";
@@ -159,6 +161,8 @@ public final class EpisimConfigGroup extends ReflectiveConfigGroup {
 	private int daysInfectious = 4;
 	private DistrictLevelRestrictions districtLevelRestrictions = DistrictLevelRestrictions.no;
 	private String districtLevelRestrictionsAttribute = "";
+	private ContagiousOptimization contagiousContainerOptimization = ContagiousOptimization.disable;
+	private ReportTimeUse reportTimeUse = ReportTimeUse.enable;
 	private int threads = 2;
 	/**
 	 * Child susceptibility used in AgeDependentInfectionModelWithSeasonality.
@@ -727,6 +731,27 @@ public final class EpisimConfigGroup extends ReflectiveConfigGroup {
 		this.districtLevelRestrictionsAttribute = districtLevelRestrictionsAttribute;
 	}
 
+	@StringGetter(CONTAGIOUS_CONTAINER_OPTIMIZATION)
+	public ContagiousOptimization getContagiousOptimization() {
+		return this.contagiousContainerOptimization;
+	}
+
+	@StringSetter(CONTAGIOUS_CONTAINER_OPTIMIZATION)
+	public void setContagiousOptimization(ContagiousOptimization contagiousOptimization) {
+		this.contagiousContainerOptimization = contagiousOptimization;
+	}
+
+	@StringGetter(REPORT_TIME_USE)
+	public ReportTimeUse getReportTimeUse() {
+		return reportTimeUse;
+	}
+
+	@StringSetter(REPORT_TIME_USE)
+	public void setReportTimeUse(ReportTimeUse reportTimeUse) {
+		this.reportTimeUse = reportTimeUse;
+	}
+	
+
 	@Override
 	public void addParameterSet(final ConfigGroup set) {
 		// this is, I think, necessary for the automatic reading from file, and possibly for the commandline stuff.
@@ -971,6 +996,26 @@ public final class EpisimConfigGroup extends ReflectiveConfigGroup {
 		yes,
 		no
 	}
+
+ 
+    /** 
+     * In the case that this optimization is enabled, the infectionDynamics
+     * methods are only called, if a contagious person is in the container
+     */	
+	public enum ContagiousOptimization {
+		enable,
+		disable
+	}
+	
+	/**
+	 * The used time tracking costs a lot of CPU cycles, so this 
+     * can be disabled with
+     */
+	public enum ReportTimeUse {
+		enable,
+		disable
+	}
+
 
 
 	/**

--- a/src/main/java/org/matsim/episim/EpisimContainer.java
+++ b/src/main/java/org/matsim/episim/EpisimContainer.java
@@ -88,6 +88,15 @@ public class EpisimContainer<T> {
 	 * The id of the ReplayEventTask that handles the events for this container
 	 */
 	private int taskId = 0;
+
+	/**
+	 * This flag is set to true at the beginning of the day,
+	 * if one person that is visiting the container at this day has the
+	 * DiseaseStatus contagious or showingSymptoms. 	
+     * 
+     * See also: EpisimPerson::markFacilities	
+	 */
+ 	private boolean containsContagiousThisDay = false;
 	
 	EpisimContainer(Id<T> containerId) {
 		this.containerId = containerId;
@@ -253,5 +262,13 @@ public class EpisimContainer<T> {
 	public List<EpisimPerson> getPersons() {
 		// Using Collections.unmodifiableList(...) puts huge pressure on the GC if its called hundred thousand times per second
 		return personsAsList;
+	}
+
+	public boolean getContainsContagiousThisDay() {
+		return containsContagiousThisDay;
+	}
+
+	public void setContainsContagiousThisDay(boolean newState) {
+		containsContagiousThisDay = newState;
 	}
 }

--- a/src/main/java/org/matsim/episim/EpisimContainer.java
+++ b/src/main/java/org/matsim/episim/EpisimContainer.java
@@ -90,14 +90,11 @@ public class EpisimContainer<T> {
 	private int taskId = 0;
 
 	/**
-	 * This flag is set to true at the beginning of the day,
-	 * if one person that is visiting the container at this day has the
-	 * DiseaseStatus contagious or showingSymptoms. 	
-     * 
-     * See also: EpisimPerson::markFacilities	
+	 * This counts the number of persons in this container
+	 * which have the DiseaseStatus contagious or showingSymptoms. 	
 	 */
- 	private boolean containsContagiousThisDay = false;
-	
+ 	private int contagiousCounter = 0;
+
 	EpisimContainer(Id<T> containerId) {
 		this.containerId = containerId;
 	}
@@ -163,6 +160,10 @@ public class EpisimContainer<T> {
 		boolean wasRemoved = personsAsList.remove(person);
 		if (!wasRemoved)
 			log.warn( "Person {} was not in container {}", person.getPersonId(), containerId);
+
+		if (person.canInfectOthers()) {
+			contagiousCounter -= 1;
+		}
 	}
 
 	/**
@@ -264,11 +265,17 @@ public class EpisimContainer<T> {
 		return personsAsList;
 	}
 
-	public boolean getContainsContagiousThisDay() {
-		return containsContagiousThisDay;
+
+	public void countContagious(int add) {
+		contagiousCounter += add;
+		assert contagiousCounter >= 0 : "We can not have a negative number of contagious persons"; 
 	}
 
-	public void setContainsContagiousThisDay(boolean newState) {
-		containsContagiousThisDay = newState;
+	public void resetContagiousCounter() {
+		contagiousCounter = 0;
+	}
+	
+	public boolean containsContagious() {
+		return contagiousCounter > 0;
 	}
 }

--- a/src/main/java/org/matsim/episim/EpisimContainer.java
+++ b/src/main/java/org/matsim/episim/EpisimContainer.java
@@ -161,9 +161,8 @@ public class EpisimContainer<T> {
 		if (!wasRemoved)
 			log.warn( "Person {} was not in container {}", person.getPersonId(), containerId);
 
-		if (person.canInfectOthers()) {
+		if (person.infectedButNotSerious())
 			contagiousCounter -= 1;
-		}
 	}
 
 	/**

--- a/src/main/java/org/matsim/episim/EpisimPerson.java
+++ b/src/main/java/org/matsim/episim/EpisimPerson.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.episim.events.EpisimInfectionEvent;
 import org.matsim.episim.events.EpisimPersonStatusEvent;
+import org.matsim.episim.InfectionEventHandler.EpisimFacility;
 import org.matsim.episim.model.VaccinationType;
 import org.matsim.episim.model.VirusStrain;
 import org.matsim.facilities.ActivityFacility;
@@ -881,4 +882,15 @@ public final class EpisimPerson implements Attributable {
 	 */
 	static final PerformedActivity UNSPECIFIC_ACTIVITY = new PerformedActivity(Double.NaN, null, null);
 
+	public void markFacilities(DayOfWeek day, Map<Id<ActivityFacility>, EpisimFacility> pseudoFacilityMap) {
+		List<PerformedActivity> activities = getActivities(day);
+		for (int i = 0; i < activities.size(); i++) {
+			// TODO: maybe check trajectory
+			//			if (trajectory.get(offset + i))
+			if (status == DiseaseStatus.contagious || status == DiseaseStatus.showingSymptoms) {
+				EpisimFacility facility = pseudoFacilityMap.get(activities.get(i).getFacilityId());
+				facility.setContainsContagiousThisDay(true);
+			}
+		}
+	}
 }

--- a/src/main/java/org/matsim/episim/EpisimPerson.java
+++ b/src/main/java/org/matsim/episim/EpisimPerson.java
@@ -882,14 +882,23 @@ public final class EpisimPerson implements Attributable {
 	 */
 	static final PerformedActivity UNSPECIFIC_ACTIVITY = new PerformedActivity(Double.NaN, null, null);
 
+	/**
+	 * This function check if the person can infect other persons and marks in this
+     * case all facilities that are visited this day 
+	 */
 	public void markFacilities(DayOfWeek day, Map<Id<ActivityFacility>, EpisimFacility> pseudoFacilityMap) {
-		List<PerformedActivity> activities = getActivities(day);
-		for (int i = 0; i < activities.size(); i++) {
-			// TODO: maybe check trajectory
-			//			if (trajectory.get(offset + i))
-			if (status == DiseaseStatus.contagious || status == DiseaseStatus.showingSymptoms) {
-				EpisimFacility facility = pseudoFacilityMap.get(activities.get(i).getFacilityId());
-				facility.setContainsContagiousThisDay(true);
+		// TODO: maybe refactor this check to a more visible function, to reduce the risk
+		// of overlooking a necessary adjustment in the event of a change in the disease model
+		if (status == DiseaseStatus.contagious || status == DiseaseStatus.showingSymptoms) {
+			int offset = this.getStartOfDay(day);
+			BitSet activityParticipation = getActivityParticipation();
+
+			List<PerformedActivity> activities = getActivities(day);
+			for (int i = 0; i < activities.size(); i++) {
+				if (activityParticipation.get(offset + i)) {
+					EpisimFacility facility = pseudoFacilityMap.get(activities.get(i).getFacilityId());
+					facility.setContainsContagiousThisDay(true);
+				}
 			}
 		}
 	}

--- a/src/main/java/org/matsim/episim/EpisimPerson.java
+++ b/src/main/java/org/matsim/episim/EpisimPerson.java
@@ -882,24 +882,8 @@ public final class EpisimPerson implements Attributable {
 	 */
 	static final PerformedActivity UNSPECIFIC_ACTIVITY = new PerformedActivity(Double.NaN, null, null);
 
-	/**
-	 * This function check if the person can infect other persons and marks in this
-     * case all facilities that are visited this day 
-	 */
-	public void markFacilities(DayOfWeek day, Map<Id<ActivityFacility>, EpisimFacility> pseudoFacilityMap) {
-		// TODO: maybe refactor this check to a more visible function, to reduce the risk
-		// of overlooking a necessary adjustment in the event of a change in the disease model
-		if (status == DiseaseStatus.contagious || status == DiseaseStatus.showingSymptoms) {
-			int offset = this.getStartOfDay(day);
-			BitSet activityParticipation = getActivityParticipation();
 
-			List<PerformedActivity> activities = getActivities(day);
-			for (int i = 0; i < activities.size(); i++) {
-				if (activityParticipation.get(offset + i)) {
-					EpisimFacility facility = pseudoFacilityMap.get(activities.get(i).getFacilityId());
-					facility.setContainsContagiousThisDay(true);
-				}
-			}
-		}
+	public boolean canInfectOthers() {
+		return (status == DiseaseStatus.contagious || status == DiseaseStatus.showingSymptoms);
 	}
 }

--- a/src/main/java/org/matsim/episim/EpisimPerson.java
+++ b/src/main/java/org/matsim/episim/EpisimPerson.java
@@ -881,8 +881,16 @@ public final class EpisimPerson implements Attributable {
 	 */
 	static final PerformedActivity UNSPECIFIC_ACTIVITY = new PerformedActivity(Double.NaN, null, null);
 
-
-	public boolean canInfectOthers() {
-		return (status == DiseaseStatus.contagious || status == DiseaseStatus.showingSymptoms);
+    /**
+	 * If the ContagiousOptimization is enabled, containers count how many 
+	 * persons satisfy this predicate to call the infectionsDynamics methods 
+     * only in the case that at least one person in the container 
+	 * can infect another (or in the infectedButNotContagious case,
+	 * inform other persons later thanks to tracking).	
+	 */
+	public boolean infectedButNotSerious() {
+		return (status == DiseaseStatus.infectedButNotContagious || 
+				status == DiseaseStatus.contagious ||
+				status == DiseaseStatus.showingSymptoms);
 	}
 }

--- a/src/main/java/org/matsim/episim/EpisimPerson.java
+++ b/src/main/java/org/matsim/episim/EpisimPerson.java
@@ -28,7 +28,6 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.episim.events.EpisimInfectionEvent;
 import org.matsim.episim.events.EpisimPersonStatusEvent;
-import org.matsim.episim.InfectionEventHandler.EpisimFacility;
 import org.matsim.episim.model.VaccinationType;
 import org.matsim.episim.model.VirusStrain;
 import org.matsim.facilities.ActivityFacility;

--- a/src/main/java/org/matsim/episim/InfectionEventHandler.java
+++ b/src/main/java/org/matsim/episim/InfectionEventHandler.java
@@ -748,6 +748,11 @@ public final class InfectionEventHandler implements Externalizable {
 		}
 		reporting.reportCpuTime(iteration, "TestingModel", "finished", -1);
 
+		reporting.reportCpuTime(iteration, "MarkFacilities", "start", -1);
+		pseudoFacilityMap.values().forEach(c -> c.setContainsContagiousThisDay(false));
+		personMap.values().parallelStream().forEach(p -> p.markFacilities(day, pseudoFacilityMap));
+		reporting.reportCpuTime(iteration, "MarkFacilities", "finished", -1);
+			
 		handlers.forEach(h -> {
 			h.setRestrictionsForIteration(iteration, im);
 			EpisimUtils.setSeed(h.getRnd(), rnd.nextLong());

--- a/src/main/java/org/matsim/episim/InfectionEventHandler.java
+++ b/src/main/java/org/matsim/episim/InfectionEventHandler.java
@@ -748,10 +748,6 @@ public final class InfectionEventHandler implements Externalizable {
 		}
 		reporting.reportCpuTime(iteration, "TestingModel", "finished", -1);
 
-		reporting.reportCpuTime(iteration, "MarkFacilities", "start", -1);
-		pseudoFacilityMap.values().forEach(c -> c.setContainsContagiousThisDay(false));
-		personMap.values().parallelStream().forEach(p -> p.markFacilities(day, pseudoFacilityMap));
-		reporting.reportCpuTime(iteration, "MarkFacilities", "finished", -1);
 			
 		handlers.forEach(h -> {
 			h.setRestrictionsForIteration(iteration, im);

--- a/src/main/java/org/matsim/episim/InfectionEventHandler.java
+++ b/src/main/java/org/matsim/episim/InfectionEventHandler.java
@@ -748,7 +748,6 @@ public final class InfectionEventHandler implements Externalizable {
 		}
 		reporting.reportCpuTime(iteration, "TestingModel", "finished", -1);
 
-			
 		handlers.forEach(h -> {
 			h.setRestrictionsForIteration(iteration, im);
 			EpisimUtils.setSeed(h.getRnd(), rnd.nextLong());

--- a/src/main/java/org/matsim/episim/TrajectoryHandler.java
+++ b/src/main/java/org/matsim/episim/TrajectoryHandler.java
@@ -259,7 +259,9 @@ final class TrajectoryHandler {
 
 		reporting.handleEvent(activityEndEvent);
 
-		contactModel.infectionDynamicsFacility(episimPerson, episimFacility, now);
+		if (episimFacility.getContainsContagiousThisDay()) {
+			contactModel.infectionDynamicsFacility(episimPerson, episimFacility, now);
+		}
 
 		double timeSpent = now - episimFacility.getContainerEnteringTime(episimPerson.getPersonId());
 		episimPerson.addSpentTime(activityEndEvent.getActType(), timeSpent);

--- a/src/main/java/org/matsim/episim/TrajectoryHandler.java
+++ b/src/main/java/org/matsim/episim/TrajectoryHandler.java
@@ -144,6 +144,8 @@ final class TrajectoryHandler {
 			if (!responsibleFacility.test(facility.getContainerId()))
 				continue;
 
+			facility.resetContagiousCounter();
+
 			Iterator<EpisimPerson> it = facility.getPersons().iterator();
 
 			while (it.hasNext()) {
@@ -164,7 +166,8 @@ final class TrajectoryHandler {
 
 					contactModel.infectionDynamicsFacility(person, facility, now);
 					facility.removePerson(person, it);
-				}
+				} else if (person.canInfectOthers())
+					facility.countContagious(1);
 			}
 		}
 
@@ -259,12 +262,15 @@ final class TrajectoryHandler {
 
 		reporting.handleEvent(activityEndEvent);
 
-		if (episimFacility.getContainsContagiousThisDay()) {
+		if (episimConfig.getContagiousOptimization() == EpisimConfigGroup.ContagiousOptimization.disable ||
+		    episimFacility.containsContagious()) {
 			contactModel.infectionDynamicsFacility(episimPerson, episimFacility, now);
 		}
 
-		double timeSpent = now - episimFacility.getContainerEnteringTime(episimPerson.getPersonId());
-		episimPerson.addSpentTime(activityEndEvent.getActType(), timeSpent);
+		if (episimConfig.getReportTimeUse() == EpisimConfigGroup.ReportTimeUse.enable) {
+			double timeSpent = now - episimFacility.getContainerEnteringTime(episimPerson.getPersonId());
+			episimPerson.addSpentTime(activityEndEvent.getActType(), timeSpent);
+		}
 
 		episimFacility.removePerson(episimPerson);
 	}
@@ -305,12 +311,17 @@ final class TrajectoryHandler {
 
 		reporting.handleEvent(leavesVehicleEvent);
 
-		contactModel.infectionDynamicsVehicle(episimPerson, episimVehicle, now);
+		if (episimConfig.getContagiousOptimization() == EpisimConfigGroup.ContagiousOptimization.disable || 
+			episimVehicle.containsContagious()) {
+			contactModel.infectionDynamicsVehicle(episimPerson, episimVehicle, now);
+		}
 
-		double timeSpent = now - episimVehicle.getContainerEnteringTime(episimPerson.getPersonId());
 
-		// This type depends on the params defined in the scenario
-		episimPerson.addSpentTime("pt", timeSpent);
+		if (episimConfig.getReportTimeUse() == EpisimConfigGroup.ReportTimeUse.enable) {
+			double timeSpent = now - episimVehicle.getContainerEnteringTime(episimPerson.getPersonId());
+
+			episimPerson.addSpentTime("pt", timeSpent);
+		}
 
 		// remove person from vehicle:
 		episimVehicle.removePerson(episimPerson);

--- a/src/main/java/org/matsim/episim/TrajectoryHandler.java
+++ b/src/main/java/org/matsim/episim/TrajectoryHandler.java
@@ -166,7 +166,7 @@ final class TrajectoryHandler {
 
 					contactModel.infectionDynamicsFacility(person, facility, now);
 					facility.removePerson(person, it);
-				} else if (person.canInfectOthers())
+				} else if (person.infectedButNotSerious())
 					facility.countContagious(1);
 			}
 		}
@@ -262,12 +262,12 @@ final class TrajectoryHandler {
 
 		reporting.handleEvent(activityEndEvent);
 
-		if (episimConfig.getContagiousOptimization() == EpisimConfigGroup.ContagiousOptimization.disable ||
+		if (episimConfig.getContagiousOptimization() == EpisimConfigGroup.ContagiousOptimization.no ||
 		    episimFacility.containsContagious()) {
 			contactModel.infectionDynamicsFacility(episimPerson, episimFacility, now);
 		}
 
-		if (episimConfig.getReportTimeUse() == EpisimConfigGroup.ReportTimeUse.enable) {
+		if (episimConfig.getReportTimeUse() == EpisimConfigGroup.ReportTimeUse.yes) {
 			double timeSpent = now - episimFacility.getContainerEnteringTime(episimPerson.getPersonId());
 			episimPerson.addSpentTime(activityEndEvent.getActType(), timeSpent);
 		}
@@ -311,13 +311,13 @@ final class TrajectoryHandler {
 
 		reporting.handleEvent(leavesVehicleEvent);
 
-		if (episimConfig.getContagiousOptimization() == EpisimConfigGroup.ContagiousOptimization.disable || 
+		if (episimConfig.getContagiousOptimization() == EpisimConfigGroup.ContagiousOptimization.no || 
 			episimVehicle.containsContagious()) {
 			contactModel.infectionDynamicsVehicle(episimPerson, episimVehicle, now);
 		}
 
 
-		if (episimConfig.getReportTimeUse() == EpisimConfigGroup.ReportTimeUse.enable) {
+		if (episimConfig.getReportTimeUse() == EpisimConfigGroup.ReportTimeUse.yes) {
 			double timeSpent = now - episimVehicle.getContainerEnteringTime(episimPerson.getPersonId());
 
 			episimPerson.addSpentTime("pt", timeSpent);


### PR DESCRIPTION
As discussed, the changes here improves the performance by calling infectionDynamicsFacility only if a contagious person is in this container at that day. In the 25% Berlin case (using DebugBatch), the improvement is about 20% (2718 instead of 3264 sec).

This fails the current tests, as the change also influence the random generator, but I have the impression, that the infection numbers are in the same range. But hopefully you have better methods to check this.

I assume that addSpentTime should be called always, if this is not the case it would be possible to filter out additional parts.